### PR TITLE
update timetable for 2024-first-half

### DIFF
--- a/src/App/Main/index.tsx
+++ b/src/App/Main/index.tsx
@@ -10,7 +10,7 @@ import type {
   DayString,
 } from "src/data/DateString";
 import { type Hours, type Minutes, pad } from "src/data/Time";
-import service from "src/data/2023s";
+import service from "src/data/2024f";
 
 // components
 import Space from "src/components/Space";

--- a/src/data/2024f.ts
+++ b/src/data/2024f.ts
@@ -1,0 +1,147 @@
+/**
+ * 2024 first half
+ * Timetable data of the bus service
+ * between Hino and Minami-Osawa campuses
+ */
+
+import Service, { type Pattern } from "./Service";
+
+/**
+ * @description
+ * The service pattern for 2024 first half.
+ */
+const pattern: Pattern = {
+  // regular days
+  ...Object.fromEntries(
+    (function* () {
+      const dayWisePatterns = [0, 2, 2, 2, 2, 2, 0];
+      const outOfService = new Date("2024-08-06"); // end of normal pattern
+
+      // yield pattern ids
+      for (
+        const date = new Date("2024-03-31");
+        date.getMonth() !== 10;
+        date.setDate(date.getDate() + 1)
+      ) {
+        const day = date.getDay();
+        const key = date.toISOString().replace(/T.+/, "");
+
+        yield [key, date >= outOfService ? 0 : dayWisePatterns[day]];
+      }
+    })()
+  ),
+
+  // irregular days
+  "2024-04-01": 0,
+  "2024-04-02": 0,
+
+  "2024-04-29": 0,
+  "2024-05-03": 0,
+  "2024-05-06": 0,
+
+  "2024-08-06": 1,
+  "2024-08-07": 1,
+  "2024-08-08": 1,
+  "2024-08-09": 1,
+  "2024-09-02": 1,
+  "2024-09-03": 1,
+  "2024-09-04": 1,
+  "2024-09-05": 1,
+  "2024-09-06": 1,
+  "2024-09-09": 1,
+  "2024-09-10": 1,
+  "2024-09-11": 1,
+  "2024-09-12": 1,
+  "2024-09-13": 1,
+
+};
+
+/**
+ * @description
+ * Bus timetables from Hino to Minami-Osawa using pattern ids as key.
+ */
+const hino = Service.createTimetable({
+  0: {},
+  1: {
+    8: [[40, []]],
+    9: [[50, [2]]],
+    12: [[20, [3]]],
+    13: [[50, [4]]],
+    15: [[20, [5]]],
+    16: [[30, [6]]],
+    18: [[30, [7]]],
+  },
+  2: {
+    7: [[50, [1]]],
+    8: [[40, []]],
+    9: [
+      [10, []],
+      [50, [2]],
+    ],
+    10: [[40, []]],
+    12: [[20, [3]]],
+    13: [
+      [0, []],
+      [50, [4]],
+    ],
+    14: [[40, []]],
+    15: [[20, [5]]],
+    16: [
+      [20, []],
+      [30, [6]],
+    ],
+    18: [
+      [10, []],
+      [30, [7]],
+    ],
+  },
+  3: {},
+  4: {},
+});
+
+/**
+ * @description
+ * Bus timetables from Minami-Osawa to Hino using pattern ids as key.
+ */
+const minao = Service.createTimetable({
+    0: {},
+    1: {
+        7: [[45, [1]]],
+        9: [[20, [2]]],
+        10: [[40, [3]]],
+        13: [[0, [4]]],
+        14: [[40, [5]]],
+        15: [[55, [6]]],
+        17: [[30, [7]]],
+    },
+    2: {
+        7: [[45, [1]]],
+        8: [[40, []]],
+        9: [
+            [20, []],
+            [50, [2]],
+        ],
+        10: [[40, []]],
+        12: [[20, [3]]],
+        13: [
+            [0, []],
+            [50, [4]],
+        ],
+        14: [[40, []]],
+        15: [
+            [30, [5]],
+            [55, []],
+        ],
+        17: [
+            [0, [6]],
+            [30, []],
+        ],
+        18: [[45, [7]]],
+    },
+    3: {},
+    4: {},
+});
+
+const service = new Service(pattern, { hino, minao });
+
+export default service;


### PR DESCRIPTION
## 概要
[2024年度前期の時刻表](https://www.tmu.ac.jp/extra/download.html?d=assets/files/download/campus/1159/202403_bus_timetable.pdf)と[運行本数](https://www.tmu.ac.jp/campuslife_career/facility/minamiosawa_hino/36554.html?d=assets/files/download/campus/1159/202403_bus_oshirase.pdf)の公式情報に基づき，時刻表データを追加しました．

## 変更点
- add: `src/data/2024f.ts`
  - 2024年度前期の時刻表情報を追加しました．
  - 平日は原則2台運行で，3台での運行日はありませんので，`const dayWisePatterns = [0, 2, 2, 2, 2, 2, 0];`としています．
  - 最終運行日を表す`outOfService`は，通常運行が終了する8月6日としています．
    - 集中講義に伴う1台運行の日が8月と9月に存在し，その間の半月間は運行がありません．これらの例外日の指定の記述を減らすためです．
  - 便のnote情報（何限に間に合う最終便であるかや，本日の最終便であるか等）も対応付けてあります．
- mod: `src/App/Main/index.tsx`
  - `src/data/2024f.ts`を参照するように変更しました．